### PR TITLE
Emit change event when native "change" occurs

### DIFF
--- a/src/components/InputColorPicker.vue
+++ b/src/components/InputColorPicker.vue
@@ -5,6 +5,7 @@
     type="color"
     v-bind:value="value"
     @input="$_icp_handleInput"
+    @change="$_icp_handleChange"
   />
 </template>
 <script>
@@ -21,6 +22,9 @@ export default {
   methods: {
     $_icp_handleInput (e) {
       this.$emit('input', e.target.value)
+    },
+    $_icp_handleChange (e) {
+      this.$emit('change', e.target.value)
     }
   }
 }


### PR DESCRIPTION
# Description

The HTML color input supports two events: `input` and `change`.  `input` is already implemented, this PR introduces `change`.

Unlike the input which fires each time a value is changed, the change event is fired one time and occurs when the user has a selected color value and closes the color picker UI, essentially giving the user the final color value that was chosen.


## Example Usage

```
<v-input-colorpicker v-model="my_color" v-on:change="handleChange"  />

handleChange(value) {
      console.log('You picked', value)
},

```
